### PR TITLE
Add link to the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 This VSCode extension provides tools for easy application development with Cloud Foundry. Its' tools contains such functionality as "Login to Cloud Foundry", "Create service", "Bind service", "Unbind service", etc.
 
+This extension is **not available in the Visual Studio Marketplace**. See the section [How to Run Locally](#how-to-run-locally) below for installation instructions.
+
 ## Table of contents
 
 - [Features](#features)


### PR DESCRIPTION
Indicate in the README file that the extension is [not available](https://github.com/SAP/cloud-foundry-tools/issues/98#issuecomment-784081786) on the VS Code Marketplace, so that users will spend less time searching for it there.