### PR TITLE
fix: sign in button disabled state

### DIFF
--- a/packages/frontend/src/components/CFSignin.vue
+++ b/packages/frontend/src/components/CFSignin.vue
@@ -243,7 +243,7 @@ export default {
     },
     setSSO(val) {
       this.ssoOrCredentials = val.target.value;
-      this.disableButton = true;
+      this.btnStatus();
     },
     SigninClicked() {
       let payload = {};


### PR DESCRIPTION
Fixes a bug where the sign in button becomes disabled after switching sign in method from Credentials to SSO