### PR TITLE
fix: fall back to direct CF lookup when UPS not found in list

### DIFF
--- a/packages/backend/src/cfViewCommands.ts
+++ b/packages/backend/src/cfViewCommands.ts
@@ -406,9 +406,13 @@ async function collectBindDetails(
           await updateInstanceNameAndTags(availableServices, serviceTypeInfo, instanceNames, tags);
         }
       } else {
-        const foundInstance = _.find(availableServices, ["label", requstedInstance]);
+        let foundInstance = _.find(availableServices, ["label", requstedInstance]);
         if (!foundInstance) {
-          throw new Error(messages.no_services_instance_byname_found(requstedInstance));
+          foundInstance = await getServiceInstanceInfo(requstedInstance).catch(() => undefined);
+          if (!foundInstance) {
+            throw new Error(messages.no_services_instance_byname_found(requstedInstance));
+          }
+          availableServices.push(foundInstance);
         }
         instanceNames.push(foundInstance.label);
         tags.push(serviceTypeInfos[0].tag);

--- a/packages/backend/tests/cfViewCommands.spec.ts
+++ b/packages/backend/tests/cfViewCommands.spec.ts
@@ -756,11 +756,37 @@ describe("cfViewCommands tests", () => {
     it("ok:: path selected, service is ServiceTypeInfo type, no ups, services found, required service not found", async () => {
       commandsMock.expects("getAvailableServices").withExactArgs(opts).resolves(services);
       commandsMock.expects("updateInstanceNameAndTags").never();
+      cfLocalMock.expects("cfGetInstanceMetadata").withExactArgs("not-existed").rejects(new Error("not found"));
       vscodeWindowMock
         .expects("showErrorMessage")
         .withArgs(messages.no_services_instance_byname_found("not-existed"))
         .resolves();
       expect(await cfViewCommands.cmdBindLocal(service, { path, ignore: true }, "not-existed")).to.be.undefined;
+    });
+
+    it("ok:: path selected, service is ServiceTypeInfo type, no ups, service not in list but found via direct lookup (CF eventual consistency)", async () => {
+      // Simulate CF list API returning stale results: services[0] missing, only services[1] present
+      commandsMock.expects("getAvailableServices").withExactArgs(opts).resolves([services[1]]);
+      commandsMock.expects("updateInstanceNameAndTags").never();
+      cfLocalMock
+        .expects("cfGetInstanceMetadata")
+        .withExactArgs(services[0].label)
+        .resolves({ serviceName: services[0].label, service: service[0].plan, plan_guid: "GUID" });
+      vscodeWindowMock
+        .expects("withProgress")
+        .withArgs({
+          location: nsVsMock.testVscode.ProgressLocation.Notification,
+          title: messages.binding_service_to_file,
+          cancellable: false,
+        })
+        .resolves();
+      vscodeWindowMock
+        .expects("showInformationMessage")
+        .withExactArgs(messages.service_bound_successful(services[0].label))
+        .resolves();
+      expect(await cfViewCommands.cmdBindLocal(service, { path, ignore: true }, services[0].label)).deep.equal({
+        instanceName: services[0].label,
+      });
     });
 
     it("ok:: path selected, service is ServiceTypeInfo type, no services, services found, ups selected, quote-vcap is true", async () => {


### PR DESCRIPTION
When binding a grantor service to a UPS, the CF Cloud Controller list API has eventual consistency — a newly created (or recently updated) instance may not appear in GET /v3/service_instances immediately, even though it exists. The requstedInstance code path threw immediately on a list miss with no fallback, causing sporadic bind failures.

Fix: if the instance is not found in the available-services list, retry via getServiceInstanceInfo() (a direct metadata lookup by name) before throwing. If found, inject the result into availableServices so the subsequent instance-resolution loop does not issue a redundant second fetch. Tests updated accordingly.

Fixes: [DEVXBUGS-12663]